### PR TITLE
Update to MainActivity.java adding new hardware type id

### DIFF
--- a/app/src/app/src/main/java/org/furrtek/pricehaxbt/MainActivity.java
+++ b/app/src/app/src/main/java/org/furrtek/pricehaxbt/MainActivity.java
@@ -288,6 +288,8 @@ public class MainActivity extends Activity {
                 MainActivity.this.hi = 128;
                 MainActivity.this.ESLType = 2;
                 break;
+            // 2021 revision of the SmartTag HD L Red 296x128 - black housing
+            case 1370:
             case 1328:
                 MainActivity.this.scaneitype.setText("Type: " + MainActivity.this.PLType + " (SmartTag HD L Red 296x128) EXPERIMENTAL");
                 MainActivity.this.wi = 296;


### PR DESCRIPTION
New hardware type ID 1370, 2021 model - SmartTag HD L 296x128 in a black housing.  Verified on v19 of the Android app through some trickery:  Without rebuilding the app, these tags work by manually replacing 1370 with 1328 in the manually entered barcode field.

Happy to send you one if you want to try it out yourself :).

Once I get my dev environment set up (ran into a ton of issues, as it has been at least a decade since I've compiled any java code, let alone an Android app), I am considering adding a manual tag settings override option for "incompatible" tag type IDs, to allow the user to specify the height, width, and color params.  